### PR TITLE
Fixed the issue of clearing the signature pad after screen rotation.

### DIFF
--- a/SignaturePad/SignaturePad.razor.cs
+++ b/SignaturePad/SignaturePad.razor.cs
@@ -105,7 +105,8 @@ namespace SignaturePad
             }
         }
 
-        private async Task UpdateImage()
+        [JSInvokable]
+        public async Task UpdateImage()
         {
             if (jsModule is not null)
             {

--- a/SignaturePad/wwwroot/sigpad.interop.js
+++ b/SignaturePad/wwwroot/sigpad.interop.js
@@ -16,7 +16,11 @@ export function setup(id, reference, options, image) {
 
 screen.orientation.onchange = function () {
     dotNetHelper.invokeMethodAsync('UpdateImage');
-};
+}
+
+window.onresize = function () {
+    dotNetHelper.invokeMethodAsync('UpdateImage');
+}
 
 export function destroy(id) {
     var identifier = "signature-" + id;

--- a/SignaturePad/wwwroot/sigpad.interop.js
+++ b/SignaturePad/wwwroot/sigpad.interop.js
@@ -1,6 +1,8 @@
 ﻿import Sigpad from "./sigpad.min.js"
+var dotNetHelper;
 
 export function setup(id, reference, options, image) {
+    dotNetHelper = reference;
     var identifier = "signature-" + id;
     var element = document.getElementById(identifier);
 
@@ -11,6 +13,10 @@ export function setup(id, reference, options, image) {
     var sigpad = Sigpad.getOrCreateInstance(element, JSON.parse(options));
     sigpad.setImage(image);
 }
+
+screen.orientation.onchange = function () {
+    dotNetHelper.invokeMethodAsync('UpdateImage');
+};
 
 export function destroy(id) {
     var identifier = "signature-" + id;


### PR DESCRIPTION
I put this project inside a .net maui app and I realized that when the screen rotates the SignaturePad was cleared.
My edit invokes the UpdateImage method in c# code, which requires the image redraw via javascript.

