### PR TITLE
Update sigpad.interop.js

### DIFF
--- a/SignaturePad/wwwroot/sigpad.interop.js
+++ b/SignaturePad/wwwroot/sigpad.interop.js
@@ -14,8 +14,15 @@ export function setup(id, reference, options, image) {
     sigpad.setImage(image);
 }
 
-screen.orientation.onchange = function () {
-    dotNetHelper.invokeMethodAsync('UpdateImage');
+if (screen.orientation != null) {
+    screen.orientation.onchange = function () {
+        dotNetHelper.invokeMethodAsync('UpdateImage');
+    }
+}
+else {
+    window.onorientationchange = function () {
+        dotNetHelper.invokeMethodAsync('UpdateImage');
+    }
 }
 
 window.onresize = function () {


### PR DESCRIPTION
Fixed a bug in sigpad.interop.js that was using screen.orientation that is not a supported API on iOS devices.